### PR TITLE
add lemmatizer support

### DIFF
--- a/stanfordcorenlp/corenlp.py
+++ b/stanfordcorenlp/corenlp.py
@@ -181,6 +181,17 @@ class StanfordCoreNLP:
         else:
             return tokens
 
+    def lemma(self, sentence):
+        r_dict = self._request('lemma', sentence)
+        words = []
+        tags = []
+        for s in r_dict['sentences']:
+            for token in s['tokens']:
+                words.append(token['originalText'])
+                tags.append(token['lemma'])
+        return list(zip(words, tags))
+
+
     def pos_tag(self, sentence):
         r_dict = self._request('pos', sentence)
         words = []


### PR DESCRIPTION
The current `stanfordcorenlp` wrapper does not have an explicit way to lemmatize sentences via Stanford CoreNLP. So I've added the support for it. 

Example of use:
```python3
>>>import stanfordcorenlp
>>>nlp = stanfordcorenlp.StanfordCoreNLP(r'../stanford-corenlp-full-2018-02-27/')
>>>print (nlp.lemma("I am happy. you are too!"))
ner [('I', 'I'), ('am', 'be'), ('happy', 'happy'), ('.', '.'), ('you', 'you'), ('are', 'be'), ('too', 'too'), ('!', '!')]
```