### PR TITLE
Corrected 'coref' function request arguments

### DIFF
--- a/stanfordcorenlp/corenlp.py
+++ b/stanfordcorenlp/corenlp.py
@@ -215,7 +215,7 @@ class StanfordCoreNLP:
                 s['basicDependencies']]
 
     def coref(self, text):
-        r_dict = self._request('coref', text)
+        r_dict = self._request(self.url, 'coref', text)
 
         corefs = []
         for k, mentions in r_dict['corefs'].items():


### PR DESCRIPTION
I corrected the function arguments for the '_request(...)' call within the 'coref' function. This was done by adding the url as the first parameter.

AKA

This: `r_dict = self._request('coref', text)`

To this: `r_dict = self._request(self.url, 'coref', text)`

On line 218