### PR TITLE
Attempt cleanup when reference count goes to zero

### DIFF
--- a/stanfordcorenlp/corenlp.py
+++ b/stanfordcorenlp/corenlp.py
@@ -127,6 +127,9 @@ class StanfordCoreNLP:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    def __del__(self):
+        self.close()
+
     def close(self):
         logging.info('Cleanup...')
         if hasattr(self, 'p'):


### PR DESCRIPTION
Attempt to cleanup the StanfordCoreNLP object when it is no
longer referenced.

There is no guarantee that __del__ will be called every time the object
reference counts goes to zero, but it's still nice to have.